### PR TITLE
feat(rs): `GateOp::normalize` to convert custom gates into well-known

### DIFF
--- a/impl/rs/src/reader/optype/qubit/well_known.rs
+++ b/impl/rs/src/reader/optype/qubit/well_known.rs
@@ -245,4 +245,26 @@ impl WellKnownGate {
             U => 3,
         }
     }
+
+    /// Returns the well known gate corresponding to the given name.
+    pub fn from_name(name: &str) -> Option<Self> {
+        let gate = match name.to_ascii_lowercase().as_str() {
+            "gphase" => Self::GPhase,
+            "i" => Self::I,
+            "x" => Self::X,
+            "y" => Self::Y,
+            "z" => Self::Z,
+            "s" => Self::S,
+            "t" => Self::T,
+            "r1" => Self::R1,
+            "rx" => Self::Rx,
+            "ry" => Self::Ry,
+            "rz" => Self::Rz,
+            "h" | "hadamard" => Self::H,
+            "u" => Self::U,
+            "swap" => Self::Swap,
+            _ => return None,
+        };
+        Some(gate)
+    }
 }


### PR DESCRIPTION
Adds a helper method to _normalize_ gate operations, detecting custom qubit gates that have an equivalent `WellKnownGate`.