### PR TITLE
ci: Add separate name for 🦀/📜 required checks steps

### DIFF
--- a/.github/workflows/ci-rs.yml
+++ b/.github/workflows/ci-rs.yml
@@ -150,7 +150,7 @@ jobs:
   # This is a meta job to mark successful completion of the required checks,
   # even if they are skipped due to no changes in the relevant files.
   required-checks:
-    name: Required checks
+    name: Required checks 🦀
     needs: [
       changes,
       rs-check,

--- a/.github/workflows/ci-schema.yml
+++ b/.github/workflows/ci-schema.yml
@@ -89,7 +89,7 @@ jobs:
   # This is a meta job to mark successful completion of the required checks,
   # even if they are skipped due to no changes in the relevant files.
   required-checks:
-    name: Required checks
+    name: Required checks 📜
     needs: [
       changes,
       capnp-schema,


### PR DESCRIPTION
It looks like github required checks only look for the _step name_, without discriminating between workflow names.

Since we have "Required checks" steps on each of the python, rust, and schema workflows we need to ensure they all have different names. (Python already had a 🐍 suffix).