### PR TITLE
ci: Re-use the justfile definition in schema check

### DIFF
--- a/.github/workflows/ci-schema.yml
+++ b/.github/workflows/ci-schema.yml
@@ -53,26 +53,12 @@ jobs:
           sudo make install
       - name: Get cargo binstall
         uses: cargo-bins/cargo-binstall@main
-      - name: Install capnproto-rust plugin
-        run: cargo binstall capnpc
-      - name: Regenerate the Rust capnp code
+      - uses: extractions/setup-just@v3
+
+      - name: Regenerate the capnp bindings
         run: |
-          capnp compile \
-            -orust:impl/rs/src \
-            --src-prefix=impl \
-            impl/capnp/jeff.capnp
-      - name: Regenerate the C++ capnp code
-        run: |
-          patch -p0 < impl/capnp/cpp_namespace.patch
-          capnp compile \
-            -oc++:impl/cpp/src \
-            --src-prefix=impl \
-            impl/capnp/jeff.capnp
-          patch -p0 -R < impl/capnp/cpp_namespace.patch
-      - name: Re-encode the test .jeff files
-        run: ./examples/encode_examples.sh
-      - name: Copy the latest capnp schema to the python package
-        run: cp impl/capnp/jeff.capnp impl/py/src/jeff-format/data/jeff.capnp
+          just update-capnp
+
       - name: Check if the generated capnproto code is up to date
         run: |
           git diff --exit-code \

--- a/justfile
+++ b/justfile
@@ -50,9 +50,9 @@ coverage-py:
 # Update the capnproto definitions.
 update-capnp:
     # Always use the latest version of capnproto-rust
-    cargo install capnpc
+    cargo binstall capnpc || cargo install capnpc
     # Copy the definition to the python package
-    cp impl/capnp/jeff.capnp impl/py/src/jeff-format/data/jeff.capnp
+    cp impl/capnp/jeff.capnp impl/py/src/jeff/data/jeff.capnp
     # Re-generate rust capnp files
     capnp compile -orust:impl/rs/src --src-prefix=impl impl/capnp/jeff.capnp
     # Re-generate c++ capnp files


### PR DESCRIPTION
Use the same code when generating capnp bindings locally and in CI, to reduce potential bugs.