### PR TITLE
rfc: collect and provide structured benchmark programs

### DIFF
--- a/rfcs/text/0032-structured-benchmark-programs.md
+++ b/rfcs/text/0032-structured-benchmark-programs.md
@@ -201,7 +201,7 @@ There are several potential drawbacks to consider with this proposal:
 - Maintenance Overhead: The addition of a new benchmark suite requires ongoing maintenance to ensure that the benchmarks remain relevant and up-to-date with the latest advancements in quantum computing and compiler technologies.
 - Complexity: Introducing structured benchmarks may increase the complexity of the Jeff repository, potentially making it more challenging for new users to navigate and understand the available resources.
 - Limited Adoption: If the benchmarks are not widely adopted by the quantum computing community, their impact may be limited, reducing the incentive for compiler developers to implement support for structured control flow.
-- Comparisons are not simple: For users, it might not be stratighforward to know what to compare against when compiling these structured programs. For a full, fair evaluation, a meaningful baseline needs to be established and a more precise methodology for comparison is likely necessary.
+- Comparisons are not simple: For users, it might not be straightforward to know what to compare against when compiling these structured programs. For a full, fair evaluation, a meaningful baseline needs to be established and a more precise methodology for comparison is likely necessary.
 
 # Rationale and alternatives
 [rationale-and-alternatives]: #rationale-and-alternatives


### PR DESCRIPTION
This PR proposes RFC 0032, which advocates for the addition of a benchmark suite for structured quantum programs.

## Problem

There is no standard benchmark suite for evaluating compiler support for structured control flow (e.g., if, for, dynamic indexing).

## Solution

Create a set of benchmarks written in Jeff to fill this gap. This will help drive compiler development, allow for better tool evaluation, and highlight Jeff's capabilities in representing these advanced programs.



This RFC outlines the initial set of benchmarks and invites community feedback.

[Rendered RFC](https://github.com/DRovara/jeff/blob/rfc/structured-benchmark-programs/rfcs/text/0032-structured-benchmark-programs.md)