### PR TITLE
ci: Update link for CQCL-hosted reusable actions

### DIFF
--- a/.github/workflows/drop-cache.yml
+++ b/.github/workflows/drop-cache.yml
@@ -5,5 +5,5 @@ on:
       - closed
 
 jobs:
-    drop-cache:
-        uses: CQCL/hugrverse-actions/.github/workflows/drop-cache.yml@main
+  drop-cache:
+    uses: Quantinuum/hugrverse-actions/.github/workflows/drop-cache.yml@main

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -13,8 +13,8 @@ on:
     types: [checks_requested]
 
 jobs:
-    check-title:
-        name: check-title
-        uses: CQCL/hugrverse-actions/.github/workflows/pr-title.yml@main
-        secrets:
-            GITHUB_PAT: ${{ secrets.HUGRBOT_PAT }}
+  check-title:
+    name: check-title
+    uses: Quantinuum/hugrverse-actions/.github/workflows/pr-title.yml@main
+    secrets:
+      GITHUB_PAT: ${{ secrets.HUGRBOT_PAT }}

--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -153,8 +153,8 @@ with QIR.
 
 ### Why not HUGR?
 
-[HUGR](https://github.com/CQCL/hugr) is a hybrid quantum-classical program representation introduced by Quantinuum and used by the
-[TKET](https://github.com/CQCL/tket2) and [Guppy](https://github.com/CQCL/guppylang) software libraries. While satisfying a lot of our intended criteria, HUGR itself was
+[HUGR](https://github.com/quantinuum/hugr) is a hybrid quantum-classical program representation introduced by Quantinuum and used by the
+[TKET](https://github.com/quantinuum/tket2) and [Guppy](https://github.com/quantinuum/guppylang) software libraries. While satisfying a lot of our intended criteria, HUGR itself was
 not designed to be an exchange format, and instead is used as an internal intermediate
 representation. In addition, HUGR contains advanced features such as type structure that has a high
 barrier to entry.

--- a/examples/catalyst_tket_opt/README.md
+++ b/examples/catalyst_tket_opt/README.md
@@ -8,7 +8,7 @@ The demo only involves one translation direction, since the reverse path has not
 in Catalyst/HUGR yet.
 
 The Catalyst converter prototype can be found [here](https://github.com/PennyLaneAI/catalyst-jeff).
-The HUGR converter prototype can be found [here](https://github.com/CQCL/hugr-jeff).
+The HUGR converter prototype can be found [here](https://github.com/quantinuum/hugr-jeff).
 
 
 ### Catalyst MLIR


### PR DESCRIPTION
We use two helper [composite actions](https://docs.github.com/en/actions/tutorials/create-actions/create-a-composite-action) in the CI checks from [CQCL/hugrverse-actions](http://github.com/quantinuum/hugrverse-actions).

The quantinuum github org recently got renamed to `Quantinuum`, so the links to the actions broke causing the CI to fail.

I updated some other links as a drive-by.