### PR TITLE
chore: Update capnp and generated rust files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,9 +46,9 @@ checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "capnp"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe8af2e2d255489928e31504fa51d86a41d040179098a8ad6828e0d11c54dcd6"
+checksum = "71338171543626713e427635f7de390328d9e85828a816a0c88d959032b34a2f"
 dependencies = [
  "embedded-io",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ missing_docs = "warn"
 
 [workspace.dependencies]
 insta = { version = "1.34.0" }
-capnp = "0.25.0"
+capnp = "0.26.0"
 cool_asserts = "2.0.3"
 criterion = "0.5.1"
 derive_more = "2.0.1"

--- a/impl/rs/src/capnp/jeff_capnp.rs
+++ b/impl/rs/src/capnp/jeff_capnp.rs
@@ -2,7 +2,7 @@
 // DO NOT EDIT.
 // source: capnp/jeff.capnp
 // capnp binary version: 1.3.0
-// capnpc crate version: 0.25.3
+// capnpc crate version: 0.26.0
 
 pub const SCHEMA_VERSION_MAJOR: u32 = 0;
 pub const SCHEMA_VERSION_MINOR: u32 = 2;
@@ -16,10 +16,10 @@ pub enum FloatPrecision {
 }
 
 impl ::capnp::introspect::Introspect for FloatPrecision {
-    fn introspect() -> ::capnp::introspect::Type { ::capnp::introspect::TypeVariant::Enum(::capnp::introspect::RawEnumSchema { encoded_node: &float_precision::ENCODED_NODE, annotation_types: float_precision::get_annotation_types }).into() }
+    fn introspect() -> ::capnp::introspect::Type { ::capnp::introspect::TypeVariant::Enum(::capnp::introspect::RawEnumSchema::new(&float_precision::ARENA, float_precision::get_annotation_types)).into() }
 }
 impl ::core::convert::From<FloatPrecision> for ::capnp::dynamic_value::Reader<'_> {
-    fn from(e: FloatPrecision) -> Self { ::capnp::dynamic_value::Enum::new(e.into(), ::capnp::introspect::RawEnumSchema { encoded_node: &float_precision::ENCODED_NODE, annotation_types: float_precision::get_annotation_types }.into()).into() }
+    fn from(e: FloatPrecision) -> Self { ::capnp::dynamic_value::Enum::new(e.into(), ::capnp::introspect::RawEnumSchema::new(&float_precision::ARENA, float_precision::get_annotation_types).into()).into() }
 }
 impl ::core::convert::TryFrom<u16> for FloatPrecision {
     type Error = ::capnp::NotInSchema;
@@ -71,6 +71,7 @@ pub(crate) static ENCODED_NODE: [::capnp::Word; 27] = [
 pub(crate) fn get_annotation_types(child_index: Option<u16>, index: u32) -> ::capnp::introspect::Type {
     ::capnp::introspect::panic_invalid_annotation_indices(child_index, index)
 }
+pub(crate) static ARENA: ::capnp::private::arena::GeneratedCodeArena = ::capnp::private::arena::GeneratedCodeArena::new(&ENCODED_NODE);
 }
 
 #[repr(u16)]
@@ -83,10 +84,10 @@ pub enum Pauli {
 }
 
 impl ::capnp::introspect::Introspect for Pauli {
-    fn introspect() -> ::capnp::introspect::Type { ::capnp::introspect::TypeVariant::Enum(::capnp::introspect::RawEnumSchema { encoded_node: &pauli::ENCODED_NODE, annotation_types: pauli::get_annotation_types }).into() }
+    fn introspect() -> ::capnp::introspect::Type { ::capnp::introspect::TypeVariant::Enum(::capnp::introspect::RawEnumSchema::new(&pauli::ARENA, pauli::get_annotation_types)).into() }
 }
 impl ::core::convert::From<Pauli> for ::capnp::dynamic_value::Reader<'_> {
-    fn from(e: Pauli) -> Self { ::capnp::dynamic_value::Enum::new(e.into(), ::capnp::introspect::RawEnumSchema { encoded_node: &pauli::ENCODED_NODE, annotation_types: pauli::get_annotation_types }.into()).into() }
+    fn from(e: Pauli) -> Self { ::capnp::dynamic_value::Enum::new(e.into(), ::capnp::introspect::RawEnumSchema::new(&pauli::ARENA, pauli::get_annotation_types).into()).into() }
 }
 impl ::core::convert::TryFrom<u16> for Pauli {
     type Error = ::capnp::NotInSchema;
@@ -147,6 +148,7 @@ pub(crate) static ENCODED_NODE: [::capnp::Word; 34] = [
 pub(crate) fn get_annotation_types(child_index: Option<u16>, index: u32) -> ::capnp::introspect::Type {
     ::capnp::introspect::panic_invalid_annotation_indices(child_index, index)
 }
+pub(crate) static ARENA: ::capnp::private::arena::GeneratedCodeArena = ::capnp::private::arena::GeneratedCodeArena::new(&ENCODED_NODE);
 }
 
 #[repr(u16)]
@@ -169,10 +171,10 @@ pub enum WellKnownGate {
 }
 
 impl ::capnp::introspect::Introspect for WellKnownGate {
-    fn introspect() -> ::capnp::introspect::Type { ::capnp::introspect::TypeVariant::Enum(::capnp::introspect::RawEnumSchema { encoded_node: &well_known_gate::ENCODED_NODE, annotation_types: well_known_gate::get_annotation_types }).into() }
+    fn introspect() -> ::capnp::introspect::Type { ::capnp::introspect::TypeVariant::Enum(::capnp::introspect::RawEnumSchema::new(&well_known_gate::ARENA, well_known_gate::get_annotation_types)).into() }
 }
 impl ::core::convert::From<WellKnownGate> for ::capnp::dynamic_value::Reader<'_> {
-    fn from(e: WellKnownGate) -> Self { ::capnp::dynamic_value::Enum::new(e.into(), ::capnp::introspect::RawEnumSchema { encoded_node: &well_known_gate::ENCODED_NODE, annotation_types: well_known_gate::get_annotation_types }.into()).into() }
+    fn from(e: WellKnownGate) -> Self { ::capnp::dynamic_value::Enum::new(e.into(), ::capnp::introspect::RawEnumSchema::new(&well_known_gate::ARENA, well_known_gate::get_annotation_types).into()).into() }
 }
 impl ::core::convert::TryFrom<u16> for WellKnownGate {
     type Error = ::capnp::NotInSchema;
@@ -284,6 +286,7 @@ pub(crate) static ENCODED_NODE: [::capnp::Word; 75] = [
 pub(crate) fn get_annotation_types(child_index: Option<u16>, index: u32) -> ::capnp::introspect::Type {
     ::capnp::introspect::panic_invalid_annotation_indices(child_index, index)
 }
+pub(crate) static ARENA: ::capnp::private::arena::GeneratedCodeArena = ::capnp::private::arena::GeneratedCodeArena::new(&ENCODED_NODE);
 }
 
 pub mod module {


### PR DESCRIPTION
Updates rust's `capnp` dependency to `0.26.0`, and re-generates the rust files by running `just update-capnp`.