### PR TITLE
ci: Enable pr-title CI check

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,6 +1,7 @@
-name: Check Conventional Commits format
+name: PR title check 📄
+
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
     types:
@@ -15,6 +16,49 @@ on:
 jobs:
   check-title:
     name: check-title
-    uses: Quantinuum/hugrverse-actions/.github/workflows/pr-title.yml@main
-    secrets:
-      GITHUB_PAT: ${{ secrets.HUGRBOT_PAT }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Validate Conventional Commit PR title
+        if: github.event_name == 'pull_request'
+        id: lint-pr-title
+        uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            ci
+            chore
+            revert
+          requireScope: false
+          ignoreLabels: |
+            ignore-semantic-pull-request
+
+      - name: Require a footer for breaking changes
+        if: github.event_name == 'pull_request'
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          if [[ "$PR_TITLE" =~ ^[^:\(]+(\(.*\))?\!: ]] && [[ "$PR_BODY" != *"BREAKING CHANGE:"* ]]; then
+            message='A title marked with ! requires a "BREAKING CHANGE:" footer in the PR body.'
+            echo "::error title=Invalid breaking-change metadata::$message"
+            echo "### ❌ Invalid breaking-change metadata" >> "$GITHUB_STEP_SUMMARY"
+            echo >> "$GITHUB_STEP_SUMMARY"
+            echo "$message" >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
+      # The title was already checked before the PR entered the merge queue.
+      - name: Accept merge queue entry
+        if: github.event_name == 'merge_group'
+        run: echo "PR title was validated before entering the merge queue."


### PR DESCRIPTION
Now that we are automatically generating release changelogs from the pr titles, we should make sure that the titles follow [semantic versioning](https://semver.org/) so they can be detected by the bots.

There was a disabled workflow before, that required a bot github token to work. This PR replaces it with a simpler definition that doesn't try to post in the thread.
Ignore the red check from the old one here.