### PR TITLE
ci: Normalize the title of release PRs

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,6 +10,7 @@
             "release-type": "python",
             "component": "jeff-format-py",
             "package-name": "jeff-format",
+            "pull-request-title-pattern": "chore(release): prepare${component} v${version}",
             "include-component-in-tag": true,
             "draft": true,
             "force-tag-creation": true,

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -8,6 +8,7 @@ release = false
 # Keep release PRs in draft until a maintainer approves the release.
 pr_draft = true
 pr_labels = ["A-rust"]
+pr_name = "chore(release): prepare {{ package }}-rs v{{ version }}"
 
 # Include the crate name and language to avoid collisions with Python and schema tags.
 git_tag_name = "{{ package }}-rs-v{{ version }}"


### PR DESCRIPTION
Small cleanup following #90; changes the name of both automated release PRs to 
- chore(release): prepare jeff-format-{py,rs} vX.Y.Z

instead of this

<img width="614" height="148" alt="image" src="https://github.com/user-attachments/assets/63be9287-e2a1-41f0-90d4-ba00545a0dd9" />
